### PR TITLE
Space in the version string caused problems with our app versioning

### DIFF
--- a/cloudflare.json
+++ b/cloudflare.json
@@ -6,7 +6,7 @@
 		"advocacy",
 		"webmaster"
 	],
-	"version": "1.0 RC",
+	"version": "1.0-rc1",
 	"contributors":
 	[
 		{


### PR DESCRIPTION
I removed the space. Hadn't realized the problem at first, but this is used in the versions filename, so important detail.
