### PR TITLE
Change whatbrowser.org link to HTTPS

### DIFF
--- a/public/javascripts/abetterbrowser.js
+++ b/public/javascripts/abetterbrowser.js
@@ -48,7 +48,7 @@ CloudFlare.define( 'abetterbrowser', [ 'cloudflare/dom', 'cloudflare/user', 'abe
 	/**
 	 * Whatbrowser link with user's language
 	 */
-	moreInformationLink = '<a href="http://www.whatbrowser.org/intl/' + language + '/" target="_blank">',
+	moreInformationLink = '<a href="https://www.whatbrowser.org/intl/' + language + '/" target="_blank">',
 	
 	/**
 	 * Translations


### PR DESCRIPTION
Changing http://www.whatbrowser.org/intl/ to https://www.whatbrowser.org/intl/ because the website supports [HTTPS](https://www.cloudflare.com/ssl) now. HTTPS provides security and authenticity, and I think it is [something that CloudFlare officially supports](https://blog.cloudflare.com/introducing-universal-ssl/). Moreover, it makes no sense to have websites running on CloudFlare support HTTPS and then have them link to a non-secure location. (At least that is why I don't use ["A Better Browser"](https://www.cloudflare.com/apps/abetterbrowser) right now.)